### PR TITLE
Integrate news API

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,8 @@
 <h1>rapidbytes.in</h1>
 <p>Coming Soon!</p>
 <p><a href="contact.html">Contact Us</a></p>
+<h2>News Sources</h2>
+<div id="news-sources">Loading news sources...</div>
+<script src="news.js"></script>
 </body>
 </html>

--- a/news.js
+++ b/news.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const container = document.getElementById('news-sources');
+    if (!container) return;
+
+    fetch('https://newsapi.org/v2/top-headlines/sources?apiKey=6d54bd8f20ee40cb8c3b119cf16ae2c1')
+        .then(response => response.json())
+        .then(data => {
+            if (data && Array.isArray(data.sources)) {
+                const list = document.createElement('ul');
+                data.sources.forEach(src => {
+                    const item = document.createElement('li');
+                    item.textContent = src.name;
+                    list.appendChild(item);
+                });
+                container.textContent = '';
+                container.appendChild(list);
+            } else {
+                container.textContent = 'No sources found.';
+            }
+        })
+        .catch(err => {
+            console.error('Error fetching news sources:', err);
+            container.textContent = 'Error loading news sources.';
+        });
+});


### PR DESCRIPTION
## Summary
- fetch NewsAPI sources via `news.js`
- display list of news sources on the homepage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847dcfc5730832ba5dd98347187127b