### PR TITLE
Update news page to use dynamic EventRegistry search

### DIFF
--- a/news.html
+++ b/news.html
@@ -6,8 +6,10 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Top US Headlines</h1>
+    <h1>Rapid World News</h1>
     <form id="search-form">
+        <input type="text" id="search-query" placeholder="Search keywords">
+        <button type="submit">Search</button>
     </form>
     <div id="news-results"></div>
     <p><a href="index.html">Back to Home</a></p>


### PR DESCRIPTION
## Summary
- add search form and update heading
- fetch EventRegistry articles for today's date by default
- include detailed query parameters in news.js

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684820c686d0832bbdfbfdd6b8747f92