### PR TITLE
Update news search with suggestions and previews

### DIFF
--- a/news.html
+++ b/news.html
@@ -6,8 +6,10 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <h1>Top US Headlines</h1>
+    <h1>Rapid World News</h1>
     <form id="search-form">
+        <input type="text" id="search-query" placeholder="Search keywords">
+        <button type="submit">Search</button>
     </form>
     <div id="news-results"></div>
     <p><a href="index.html">Back to Home</a></p>

--- a/style.css
+++ b/style.css
@@ -24,6 +24,23 @@ p {
     text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.7); /* Added text shadow for better readability */
 }
 
+#news-results ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+#news-results li {
+    margin: 1em 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
+    padding-bottom: 1em;
+}
+
+#news-results p {
+    text-align: left;
+    font-size: 1em;
+    line-height: 1.4em;
+}
+
 a {
     color: #ADD8E6; /* Light blue for links */
     text-decoration: none;


### PR DESCRIPTION
## Summary
- show article preview snippets on the news page
- fetch concept suggestions for user search terms
- use returned suggestions as keywords in EventRegistry query
- style news results list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684820c686d0832bbdfbfdd6b8747f92