### PR TITLE
Improve news search using concept URIs

### DIFF
--- a/news.js
+++ b/news.js
@@ -1,5 +1,8 @@
+// Fetch and display news articles
+// Uses EventRegistry suggestConceptsFast API to retrieve concept URI from user query
+// Then queries articles by concept URI for today's date
+
 document.addEventListener('DOMContentLoaded', () => {
-    // EventRegistry API key
     const API_KEY = '7de5b262-507d-47bf-b589-fdca0a7ba4b8';
     const resultsContainer = document.getElementById('news-results');
     const form = document.getElementById('search-form');
@@ -8,35 +11,28 @@ document.addEventListener('DOMContentLoaded', () => {
     form.addEventListener('submit', async e => {
         e.preventDefault();
         const term = searchInput.value.trim();
-        const keywords = await getSuggestions(term);
-        if (term && !keywords.includes(term)) {
-            keywords.unshift(term);
-        }
-        fetchNews(keywords);
+        const uri = await getConceptUri(term);
+        fetchNews(uri);
     });
 
+    // Load today's news on page load
     fetchNews();
 
-    async function getSuggestions(prefix) {
-        if (!prefix) {
-            return [];
-        }
+    async function getConceptUri(term) {
+        if (!term) return null;
+        const url = `https://eventregistry.org/api/v1/suggestConceptsFast?prefix=${encodeURIComponent(term)}&lang=eng&apiKey=${API_KEY}`;
         try {
-            const url = `https://eventregistry.org/api/v1/suggestConceptsFast?prefix=${encodeURIComponent(prefix)}&lang=eng&apiKey=${API_KEY}`;
             const resp = await fetch(url);
             if (!resp.ok) throw new Error('Failed suggestions');
             const data = await resp.json();
-            if (Array.isArray(data)) {
-                return data.map(c => c.label || c.title || c.id).filter(Boolean);
-            } else if (data && data.concepts) {
-                return data.concepts.map(c => c.label || c.title || c.id).filter(Boolean);
-            } else if (data && data.suggestions) {
-                return data.suggestions.map(c => c.label || c.title || c.id).filter(Boolean);
-            }
+            const suggestion = Array.isArray(data)
+                ? data[0]
+                : (data && data.concepts ? data.concepts[0] : (data && data.suggestions ? data.suggestions[0] : null));
+            return suggestion && suggestion.uri ? suggestion.uri : null;
         } catch (err) {
-            console.error('Error fetching suggestions:', err);
+            console.error('Error fetching concept URI:', err);
+            return null;
         }
-        return [];
     }
 
     function renderArticles(articles) {
@@ -64,59 +60,28 @@ document.addEventListener('DOMContentLoaded', () => {
         resultsContainer.appendChild(list);
     }
 
-    function buildQuery(term) {
+    function buildQuery(uri) {
         const today = new Date().toISOString().slice(0, 10);
-        if (term) {
-            return {
-                "$query": {
-                    "$and": [
-                        { "keyword": term, "keywordLoc": "title" },
-                        { "keyword": term, "keywordLoc": "body" },
-                        { "dateStart": today, "dateEnd": today }
-                    ]
-                }
-            };
-        }
-        return { "$query": { "dateStart": today, "dateEnd": today } };
-    }
-
-    function fetchNews(term = '') {
-        const queryObj = buildQuery(term);
-        const query = encodeURIComponent(JSON.stringify(queryObj));
-        let url = `https://eventregistry.org/api/v1/article/getArticles?query=${query}&resultType=articles&articlesSortBy=date&includeArticleSocialScore=true&includeArticleConcepts=true&includeArticleCategories=true&includeArticleLocation=true&includeArticleImage=true&includeArticleVideos=true&includeArticleLinks=true&includeArticleExtractedDates=true&includeArticleDuplicateList=true&includeArticleOriginalArticle=true&apiKey=${API_KEY}`;
-        fetch(url)
-            .then(resp => {
-                if (!resp.ok) {
-                    throw new Error('Network response was not ok');
-                }
-                return resp.json();
-            })
-            .then(data => {
-                const articles = (data.articles && data.articles.results) ? data.articles.results : [];
-                renderArticles(articles);
-            })
-            .catch(err => {
-                console.error('Error fetching news:', err);
-                resultsContainer.textContent = 'Error loading news.';
-            });
+        const conditions = [{ dateStart: today, dateEnd: today }];
+        if (uri) {
+            conditions.push({ conceptUri: uri });
         }
         return { "$query": { "$and": conditions } };
     }
 
-    async function fetchNews(keywords = []) {
-        const queryObj = buildQuery(keywords);
+    async function fetchNews(uri = null) {
+        const queryObj = buildQuery(uri);
         const query = encodeURIComponent(JSON.stringify(queryObj));
         const url = `https://eventregistry.org/api/v1/article/getArticles?query=${query}&resultType=articles&articlesSortBy=date&includeArticleSocialScore=true&includeArticleConcepts=true&includeArticleCategories=true&includeArticleLocation=true&includeArticleImage=true&includeArticleVideos=true&includeArticleLinks=true&includeArticleExtractedDates=true&includeArticleDuplicateList=true&includeArticleOriginalArticle=true&apiKey=${API_KEY}`;
         try {
             const resp = await fetch(url);
             if (!resp.ok) throw new Error('Network response was not ok');
             const data = await resp.json();
-            const articles = (data.articles && data.articles.results) ? data.articles.results : [];
+            const articles = data.articles && data.articles.results ? data.articles.results : [];
             renderArticles(articles);
         } catch (err) {
             console.error('Error fetching news:', err);
             resultsContainer.textContent = 'Error loading news.';
         }
     }
-
 });

--- a/style.css
+++ b/style.css
@@ -27,12 +27,18 @@ p {
 #news-results ul {
     list-style-type: none;
     padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+    justify-content: center;
 }
 
 #news-results li {
-    margin: 1em 0;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.3);
-    padding-bottom: 1em;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    padding: 1em;
+    width: 250px;
+    background-color: rgba(0, 0, 0, 0.5);
+    border-radius: 4px;
 }
 
 #news-results p {
@@ -48,6 +54,18 @@ a {
 
 a:hover {
     text-decoration: underline;
+}
+
+#search-form {
+    display: flex;
+    justify-content: center;
+    margin: 1em 0 2em;
+}
+
+#search-query {
+    width: 60%;
+    max-width: 400px;
+    margin-right: 0.5em;
 }
 
 /* Optional: A semi-transparent overlay for better text contrast if needed later


### PR DESCRIPTION
## Summary
- search form placed centrally and wider
- show news results in tile layout
- resolve duplicate code in `news.js`
- fetch concept URI from EventRegistry suggestion API before querying for news

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482ce1b144832b9f1c2072e6ee4a1b