### PR TITLE
Fix preview image size

### DIFF
--- a/style.css
+++ b/style.css
@@ -94,8 +94,9 @@ body::before {
 */
 
 #news-results li img {
-    max-width: 100%;
-    height: auto;
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
     margin-bottom: 0.5em;
     border-radius: 3px;
 }


### PR DESCRIPTION
## Summary
- constrain preview images in news results to a fixed width and height

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848395e9d08832b8d0868a0efa3f49a