### PR TITLE
Fix duplicate news results and style cards

### DIFF
--- a/news.js
+++ b/news.js
@@ -42,8 +42,12 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
         const list = document.createElement('ul');
+        const seen = new Set();
         articles.forEach(article => {
+            if (seen.has(article.url)) return;
+            seen.add(article.url);
             const item = document.createElement('li');
+            item.className = 'news-item';
             if (article.image) {
                 const img = document.createElement('img');
                 img.src = article.image;

--- a/style.css
+++ b/style.css
@@ -44,12 +44,15 @@ p {
     justify-content: center;
 }
 
-#news-results li {
+#news-results li,
+.news-item {
     border: 1px solid rgba(255, 255, 255, 0.3);
     padding: 1em;
     width: 250px;
     background-color: rgba(0, 0, 0, 0.5);
     border-radius: 4px;
+    overflow: hidden;
+    margin: 0.5em;
 }
 
 #news-results p {
@@ -93,7 +96,7 @@ body::before {
 }
 */
 
-#news-results li img {
+.news-item img {
     width: 100%;
     height: 150px;
     object-fit: cover;


### PR DESCRIPTION
## Summary
- deduplicate news articles by URL before rendering
- add `.news-item` class and adjust CSS for borders and overflow
- ensure images fit within each news card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483abb1b20832bb0a2cf0113320c7b